### PR TITLE
docs: fix simple typo, comand -> command

### DIFF
--- a/Binary/howto.md
+++ b/Binary/howto.md
@@ -118,7 +118,7 @@ Note the backslash at the end of vmscfgdir.
 
 After that save script changes.
 
-Type it in comand line prompt and add your VM name as parameter, e.g. in our case: 
+Type it in command line prompt and add your VM name as parameter, e.g. in our case: 
 
 <img src="https://raw.githubusercontent.com/hfiref0x/VBoxHardenedLoader/master/Binary/help/10_script.png" />
 


### PR DESCRIPTION
There is a small typo in Binary/howto.md.

Should read `command` rather than `comand`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md