### PR TITLE
Workaround for issue #93

### DIFF
--- a/Binary/data/hidevm_ahci.cmd
+++ b/Binary/data/hidevm_ahci.cmd
@@ -65,6 +65,8 @@ set /p VM="Input Name of VM: "
 %vboxman% modifyvm "%VM%" --hpet on
 %vboxman% modifyvm "%VM%" --nestedpaging on
 %vboxman% modifyvm "%VM%" --largepages on
+%vboxman% modifyvm "%VM%" --graphicscontroller vmsvga
+%vboxman% modifyvm "%VM%" --mouse ps2
 
 cd /d %vmscfgdir%
 

--- a/Binary/data/hidevm_efiahci.cmd
+++ b/Binary/data/hidevm_efiahci.cmd
@@ -64,6 +64,8 @@ set /p VM="Input Name of VM: "
 %vboxman% modifyvm "%VM%" --hpet on
 %vboxman% modifyvm "%VM%" --nestedpaging on
 %vboxman% modifyvm "%VM%" --largepages on
+%vboxman% modifyvm "%VM%" --graphicscontroller vmsvga
+%vboxman% modifyvm "%VM%" --mouse ps2
 
 cd /d %vmscfgdir%
 

--- a/Binary/data/hidevm_efiide.cmd
+++ b/Binary/data/hidevm_efiide.cmd
@@ -63,6 +63,8 @@ set /p VM="Input Name of VM: "
 %vboxman% modifyvm "%VM%" --hpet on
 %vboxman% modifyvm "%VM%" --nestedpaging on
 %vboxman% modifyvm "%VM%" --largepages on
+%vboxman% modifyvm "%VM%" --graphicscontroller vmsvga
+%vboxman% modifyvm "%VM%" --mouse ps2
 
 cd /d %vmscfgdir%
 

--- a/Binary/data/hidevm_ide.cmd
+++ b/Binary/data/hidevm_ide.cmd
@@ -64,6 +64,8 @@ set /p VM="Input Name of VM: "
 %vboxman% modifyvm "%VM%" --hpet on
 %vboxman% modifyvm "%VM%" --nestedpaging on
 %vboxman% modifyvm "%VM%" --largepages on
+%vboxman% modifyvm "%VM%" --graphicscontroller vmsvga
+%vboxman% modifyvm "%VM%" --mouse ps2
 
 cd /d %vmscfgdir%
 %vboxman% setextradata "%VM%" "VBoxInternal/Devices/acpi/0/Config/DsdtFilePath" "%vmscfgdir%ACPI-DSDT.bin"

--- a/Binary/data/linux/hidevm_bios.sh
+++ b/Binary/data/linux/hidevm_bios.sh
@@ -59,3 +59,5 @@ vboxmanage modifyvm "$1" --longmode on
 vboxmanage modifyvm "$1" --hpet on
 vboxmanage modifyvm "$1" --nestedpaging on
 vboxmanage modifyvm "$1" --largepages on
+vboxmanage modifyvm "$1" --graphicscontroller vmsvga
+vboxmanage modifyvm "$1" --mouse ps2

--- a/Binary/data/linux/hidevm_efi.sh
+++ b/Binary/data/linux/hidevm_efi.sh
@@ -58,3 +58,5 @@ vboxmanage modifyvm "$1" --longmode on
 vboxmanage modifyvm "$1" --hpet on
 vboxmanage modifyvm "$1" --nestedpaging on
 vboxmanage modifyvm "$1" --largepages on
+vboxmanage modifyvm "$1" --graphicscontroller vmsvga
+vboxmanage modifyvm "$1" --mouse ps2

--- a/Binary/howto.md
+++ b/Binary/howto.md
@@ -48,7 +48,7 @@ After VM (vm0 is our case) created, open it setting and do some changes.
 
 On "Motherboard" tab ensure Enable I/O APIC is turned on. If you plan to use EFI please read Appendix A: Using EFI VM.
 
-On "Motherboard" tab also ensure that the Pointing Device is set to PS/2 Mouse.
+On "Motherboard" tab also ensure that the Pointing Device is set to PS/2 Mouse. You may want to disable "Enhance pointer precision" in Windows Mouse settings as it will make it work much better.
 
 <img src="https://raw.githubusercontent.com/hfiref0x/VBoxHardenedLoader/master/Binary/help/4_settings_mb.png" />
 

--- a/Binary/howto.md
+++ b/Binary/howto.md
@@ -48,6 +48,8 @@ After VM (vm0 is our case) created, open it setting and do some changes.
 
 On "Motherboard" tab ensure Enable I/O APIC is turned on. If you plan to use EFI please read Appendix A: Using EFI VM.
 
+On "Motherboard" tab also ensure that the Pointing Device is set to PS/2 Mouse.
+
 <img src="https://raw.githubusercontent.com/hfiref0x/VBoxHardenedLoader/master/Binary/help/4_settings_mb.png" />
 
 On "Processor" tab ensure PAE/NX enabled. Also note that your VM must have at least TWO CPUs because again number of processors used by malware to determinate VM execution. So give VM at minimum two processors.
@@ -60,7 +62,7 @@ On "Acceleration" tab set Paravirtualization Interface to "Legacy" and enable VT
 
 #### Display
 
-On "Screen" tab disable 3D/2D Acceleration.
+On "Screen" tab disable 3D/2D Acceleration and set the Graphics Controller to VMSVGA.
 
 <img src="https://raw.githubusercontent.com/hfiref0x/VBoxHardenedLoader/master/Binary/help/7_display.png" />
 


### PR DESCRIPTION
# Summary

This PR works around issue #93 allowing for the evasion of VM detection as long as changing hardware device IDs is not implemented. It may not ever be implemented, as this could break drivers, though.

Resolve #93.
